### PR TITLE
add ious inside the fiftyone objects

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -19,7 +19,7 @@ pipeline:
   seed: 42
   k_shots: 2 # how much sample to draw randomly in the dataset
   min_area: 10 # the minimum area of the segmentation mask to be considered valid in ground truth
-  num_points: 5 # number of single click points to segment from
+  num_points: 1 # number of single click points to segment from
   use_bounding_box: True # use bounding box in addition to points
 
 visualization:

--- a/sam_prediction_visualization.py
+++ b/sam_prediction_visualization.py
@@ -46,6 +46,7 @@ def show_in_fiftyone(cfg: DictConfig) -> None:
             random_points=pxt_table.random_points,
             sam_logits=pxt_table.sam_logits if cfg.visualization.show_logits else None,
             sam_masks=pxt_table.sam_masks if cfg.visualization.show_mask else None,
+            sam_ious=pxt_table.sam_ious,
             tmp_dir=tmp_dir,
         )
         fo_dataset = fo.Dataset.from_importer(importer)

--- a/src/data.py
+++ b/src/data.py
@@ -232,6 +232,7 @@ class PxtSAMSingleClickDatasetImporter(foud.LabeledImageDatasetImporter):
         connected_components = row[self.input_positions["connected_components"]]
         bounding_boxes = row[self.input_positions["bounding_boxes"]]
         random_points = row[self.input_positions["random_points"]]
+        sam_ious = row[self.input_positions["sam_ious"]]
         sam_logits: None | np.ndarray = (
             row[self.input_positions["sam_logits"]]
             if "sam_logits" in self.input_positions
@@ -242,7 +243,6 @@ class PxtSAMSingleClickDatasetImporter(foud.LabeledImageDatasetImporter):
             if "sam_masks" in self.input_positions
             else None
         )
-        sam_ious = row[self.input_positions["sam_ious"]]
 
         assert isinstance(img, Image), "Image data must be a PIL Image"
         metadata = fo.ImageMetadata(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -98,6 +98,7 @@ class TestPxtSAMSingleClickDatasetImporter:
         random_points_expr = MagicMock()
         sam_logits_expr = MagicMock()
         sam_masks_expr = MagicMock()
+        sam_ious_expr = MagicMock()
 
         # Mock the image expression to have .col.is_stored and .localpath
         image_expr.col.is_stored = True
@@ -119,6 +120,7 @@ class TestPxtSAMSingleClickDatasetImporter:
             np.ones((1, 10, 10)),
             np.array([[2, 2, 7, 7]]),  # bounding box
             np.ones((1, 1, 2)),
+            np.ones((1, 1)),
             np.ones((1, 1, 6, 10, 10)),
             np.ones((1, 1, 10, 10)),
         ]
@@ -135,6 +137,7 @@ class TestPxtSAMSingleClickDatasetImporter:
             random_points=random_points_expr,
             sam_logits=sam_logits_expr,
             sam_masks=sam_masks_expr,
+            sam_ious=sam_ious_expr,
             tmp_dir=str(tmp_path),
             dataset_dir=None,
         )
@@ -146,13 +149,10 @@ class TestPxtSAMSingleClickDatasetImporter:
         assert isinstance(result[0], str)
         assert isinstance(result[1], fo.ImageMetadata)
         assert isinstance(result[2], dict)
-        assert len(result[2]) == 9
+        assert len(result[2]) == 6
         assert isinstance(result[2]["ground_truth"], fo.Detections)
         assert isinstance(result[2]["random_points_0"], fo.Keypoints)
         assert isinstance(result[2]["sam_logit_0_0_0"], fo.Heatmap)
         assert isinstance(result[2]["sam_logit_0_0_1"], fo.Heatmap)
         assert isinstance(result[2]["sam_logit_0_0_2"], fo.Heatmap)
-        assert isinstance(result[2]["sam_iou_0_0_0"], fo.Classification)
-        assert isinstance(result[2]["sam_iou_0_0_1"], fo.Classification)
-        assert isinstance(result[2]["sam_iou_0_0_2"], fo.Classification)
         assert isinstance(result[2]["sam_mask_0_0"], fo.Segmentation)


### PR DESCRIPTION
This pull request introduces enhancements to the SAM single-click segmentation pipeline, focusing on improving data visualization and incorporating IoU (Intersection over Union) metrics for better confidence scoring and analysis. The changes include updates to the configuration file, the SAM dataset importer, and various methods for converting segmentation data into FiftyOne-compatible formats.

### Configuration Updates:
* [`config/config.yaml`](diffhunk://#diff-38df760413887d0cc4ee5707919e6390456a863d326f6080644cc3d9c72e4bbaL22-R22): Reduced `num_points` from 5 to 1 for single-click segmentation experiments, simplifying the segmentation process.

### Enhancements to SAM Dataset Importer:
* [`src/data.py`](diffhunk://#diff-eded5a7097c195f47aa041a7a39926fac051a99eb721d4eb3173833312df6646L152-R159): Updated the `PxtSAMSingleClickDatasetImporter` class to include IoU (`sam_ious`) metrics in ground truth, random points, segmentations, and heatmaps, enabling confidence scoring and detailed visualization. [[1]](diffhunk://#diff-eded5a7097c195f47aa041a7a39926fac051a99eb721d4eb3173833312df6646L152-R159) [[2]](diffhunk://#diff-eded5a7097c195f47aa041a7a39926fac051a99eb721d4eb3173833312df6646R173) [[3]](diffhunk://#diff-eded5a7097c195f47aa041a7a39926fac051a99eb721d4eb3173833312df6646R193)

### Visualization Improvements:
* [`sam_prediction_visualization.py`](diffhunk://#diff-aca700426d4ecc41dbd866e9a702559f8960206a3ebb2f03006c0b5152089fe1R49): Added `sam_ious` to the visualization pipeline, allowing IoU metrics to be displayed alongside masks and logits.

### IoU Integration in Data Conversion Methods:
* `src/data.py`: Modified methods such as `ground_truth_to_fo`, `random_points_to_fo`, `sam_logits_to_fo`, and `sam_masks_to_fo` to incorporate IoU values for confidence scoring and visualization. Changes include:
  - Ground truth detections now use the minimum IoU value for confidence scoring. [[1]](diffhunk://#diff-eded5a7097c195f47aa041a7a39926fac051a99eb721d4eb3173833312df6646R304) [[2]](diffhunk://#diff-eded5a7097c195f47aa041a7a39926fac051a99eb721d4eb3173833312df6646R347-R386)
  - Random points and segmentations now include IoU metrics as attributes. [[1]](diffhunk://#diff-eded5a7097c195f47aa041a7a39926fac051a99eb721d4eb3173833312df6646R396-R404) [[2]](diffhunk://#diff-eded5a7097c195f47aa041a7a39926fac051a99eb721d4eb3173833312df6646L395-R479)
  - Heatmaps now include predicted IoU values.

### Miscellaneous Updates:
* [`src/data.py`](diffhunk://#diff-eded5a7097c195f47aa041a7a39926fac051a99eb721d4eb3173833312df6646L16): Removed unused imports, such as `ObjectId`, to clean up the codebase.