### PR TITLE
Simplify the fo importer to only use the pxt table as input

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -23,8 +23,8 @@ pipeline:
   use_bounding_box: True # use bounding box in addition to points
 
 visualization:
-  show_logits: False # show logits in the visualization
-  show_mask: True # show mask in the visualization
+  show_sam_logits: False # show logits in the visualization
+  show_sam_mask: True # show mask in the visualization
 
 logging:
   mlflow_tracking_uri: /storage/ml/mlruns

--- a/sam_prediction_visualization.py
+++ b/sam_prediction_visualization.py
@@ -38,15 +38,8 @@ def show_in_fiftyone(cfg: DictConfig) -> None:
         )
         importer = PxtSAMSingleClickDatasetImporter(
             pxt_table=pxt_table,
-            image=pxt_table.image,
-            label=pxt_table.label,
-            index=pxt_table.index,
-            connected_components=pxt_table.connected_components,
-            bounding_boxes=pxt_table.bounding_boxes,
-            random_points=pxt_table.random_points,
-            sam_logits=pxt_table.sam_logits if cfg.visualization.show_logits else None,
-            sam_masks=pxt_table.sam_masks if cfg.visualization.show_mask else None,
-            sam_ious=pxt_table.sam_ious,
+            show_sam_logits=cfg.visualization.show_sam_logits,
+            show_sam_masks=cfg.visualization.show_sam_mask,
             tmp_dir=tmp_dir,
         )
         fo_dataset = fo.Dataset.from_importer(importer)

--- a/src/data.py
+++ b/src/data.py
@@ -21,7 +21,7 @@ from torchvision.transforms.v2 import functional as F
 
 
 import pixeltable as pxt
-from pixeltable import catalog, exprs
+from pixeltable import catalog
 from pixeltable.type_system import ColumnType
 
 from src.utils import logger
@@ -162,15 +162,8 @@ class PxtSAMSingleClickDatasetImporter(foud.LabeledImageDatasetImporter):
     def __init__(
         self,
         pxt_table: pxt.Table,
-        image: exprs.Expr,
-        index: exprs.Expr,
-        label: exprs.Expr,
-        connected_components: exprs.Expr,
-        bounding_boxes: exprs.Expr,
-        random_points: exprs.Expr,
-        sam_logits: exprs.Expr | None,
-        sam_masks: exprs.Expr | None,
-        sam_ious: exprs.Expr,
+        show_sam_logits: bool,
+        show_sam_masks: bool,
         tmp_dir: str,
         dataset_dir: Optional[os.PathLike] = None,
     ):
@@ -179,31 +172,30 @@ class PxtSAMSingleClickDatasetImporter(foud.LabeledImageDatasetImporter):
         )
 
         self.tmp_dir = tmp_dir
-        self.has_masks = sam_masks is not None
 
         inputs = (
             {
-                "image": image,
-                "file": image.localpath,
-                "label": label,
-                "index": index,
-                "connected_components": connected_components,
-                "bounding_boxes": bounding_boxes,
-                "random_points": random_points,
-                "sam_ious": sam_ious,
+                "image": pxt_table.image,
+                "file": pxt_table.image.localpath,
+                "label": pxt_table.label,
+                "index": pxt_table.index,
+                "connected_components": pxt_table.connected_components,
+                "bounding_boxes": pxt_table.bounding_boxes,
+                "random_points": pxt_table.random_points,
+                "sam_ious": pxt_table.sam_ious,
             }
             | (
                 {
-                    "sam_logits": sam_logits,
+                    "sam_logits": pxt_table.sam_logits,
                 }
-                if sam_logits is not None
+                if show_sam_logits
                 else {}
             )
             | (
                 {
-                    "sam_masks": sam_masks,
+                    "sam_masks": pxt_table.sam_masks,
                 }
-                if sam_masks is not None
+                if show_sam_masks
                 else {}
             )
         )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -90,31 +90,31 @@ class TestPxtSAMSingleClickDatasetImporter:
     def test_importer_next(self, tmp_path: Path) -> None:
         # Setup mocks for pxt_table and exprs
         pxt_table = MagicMock()
-        image_expr = MagicMock()
-        label_expr = MagicMock()
-        index_expr = MagicMock()
-        connected_components_expr = MagicMock()
-        bounding_boxes_expr = MagicMock()
-        random_points_expr = MagicMock()
-        sam_logits_expr = MagicMock()
-        sam_masks_expr = MagicMock()
-        sam_ious_expr = MagicMock()
+        pxt_table.image = MagicMock()
+        pxt_table.label = MagicMock()
+        pxt_table.index = MagicMock()
+        pxt_table.connected_components = MagicMock()
+        pxt_table.bounding_boxes = MagicMock()
+        pxt_table.random_points = MagicMock()
+        pxt_table.sam_ious = MagicMock()
+        pxt_table.sam_logits = MagicMock()
+        pxt_table.sam_masks = MagicMock()
 
         # Mock the image expression to have .col.is_stored and .localpath
-        image_expr.col.is_stored = True
-        image_expr.localpath = str(tmp_path / "image.png")
+        pxt_table.image.col.is_stored = True
+        pxt_table.image.localpath = str(tmp_path / "image.png")
 
         # Mock the DataFrame returned by pxt_table.select
         df_mock = MagicMock()
 
         # Create a dummy image and save it to the local path
         img = PIL.Image.new("RGB", (10, 10))
-        img.save(image_expr.localpath)
+        img.save(pxt_table.image.localpath)
 
         # Prepare a fake row: [image, file, label, index, connected_components, boxes, points, sam_logits, sam_masks,]
         row = [
             img,
-            image_expr.localpath,
+            pxt_table.image.localpath,
             "label",
             0,
             np.ones((1, 10, 10)),
@@ -129,15 +129,8 @@ class TestPxtSAMSingleClickDatasetImporter:
 
         importer = data.PxtSAMSingleClickDatasetImporter(
             pxt_table=pxt_table,
-            image=image_expr,
-            index=index_expr,
-            label=label_expr,
-            connected_components=connected_components_expr,
-            bounding_boxes=bounding_boxes_expr,
-            random_points=random_points_expr,
-            sam_logits=sam_logits_expr,
-            sam_masks=sam_masks_expr,
-            sam_ious=sam_ious_expr,
+            show_sam_logits=True,
+            show_sam_masks=True,
             tmp_dir=str(tmp_path),
             dataset_dir=None,
         )


### PR DESCRIPTION
This pull request refactors the handling of SAM logits and masks in the visualization pipeline and simplifies the `PxtSAMSingleClickDatasetImporter` class by consolidating input parameters. It also updates related test cases and configuration files to align with these changes.

### Refactoring of SAM logits and masks:

* [`config/config.yaml`](diffhunk://#diff-38df760413887d0cc4ee5707919e6390456a863d326f6080644cc3d9c72e4bbaL26-R27): Renamed `show_logits` and `show_mask` to `show_sam_logits` and `show_sam_mask` in the visualization configuration section.
* [`sam_prediction_visualization.py`](diffhunk://#diff-aca700426d4ecc41dbd866e9a702559f8960206a3ebb2f03006c0b5152089fe1L41-R42): Updated the `show_in_fiftyone` function to pass `show_sam_logits` and `show_sam_masks` directly from the configuration instead of conditional expressions.

### Simplification of `PxtSAMSingleClickDatasetImporter`:

* [`src/data.py`](diffhunk://#diff-eded5a7097c195f47aa041a7a39926fac051a99eb721d4eb3173833312df6646L165-R166): Removed individual parameters like `image`, `label`, `index`, and others from the `PxtSAMSingleClickDatasetImporter` class constructor, replacing them with direct access to `pxt_table` attributes. Added boolean flags `show_sam_logits` and `show_sam_masks` for conditional inclusion of logits and masks. [[1]](diffhunk://#diff-eded5a7097c195f47aa041a7a39926fac051a99eb721d4eb3173833312df6646L165-R166) [[2]](diffhunk://#diff-eded5a7097c195f47aa041a7a39926fac051a99eb721d4eb3173833312df6646L182-R198)

### Updates to test cases:

* [`tests/test_data.py`](diffhunk://#diff-60fb0a496fe1cd67d38a04f3cfde59201fe9bff091439e2d07eb834e1ba62f3aL93-R117): Refactored the test setup for `PxtSAMSingleClickDatasetImporter` to mock attributes directly on `pxt_table` instead of creating separate mock expressions for each parameter. Updated the test to use the new `show_sam_logits` and `show_sam_masks` flags. [[1]](diffhunk://#diff-60fb0a496fe1cd67d38a04f3cfde59201fe9bff091439e2d07eb834e1ba62f3aL93-R117) [[2]](diffhunk://#diff-60fb0a496fe1cd67d38a04f3cfde59201fe9bff091439e2d07eb834e1ba62f3aL132-R133)

### Code cleanup:

* [`src/data.py`](diffhunk://#diff-eded5a7097c195f47aa041a7a39926fac051a99eb721d4eb3173833312df6646L24-R24): Removed unused imports, specifically `exprs`, to streamline the code.