### PR TITLE
allow to list the existing tables in the experiment

### DIFF
--- a/pixeltable_status.py
+++ b/pixeltable_status.py
@@ -1,0 +1,42 @@
+from logging import getLogger
+
+import hydra
+from omegaconf import DictConfig
+
+import pixeltable as pxt
+
+from src.utils import (
+    get_pxt_dir_name_for_sam_single_click,
+    get_ground_truth_labels_for_sam_single_click,
+)
+
+logger = getLogger(__name__)
+
+
+@hydra.main(version_base=None, config_path="config/", config_name="config")
+def show_pixeltable_status(cfg: DictConfig) -> None:
+    pxt_dir_name = get_pxt_dir_name_for_sam_single_click(
+        cfg,
+    )
+    logger.info(f"Searching runs in {pxt_dir_name}.")
+    pxt_run_names = pxt.list_dirs(pxt_dir_name)
+    for pxt_run_name in pxt_run_names:
+        logger.info(f"Searching tables in {pxt_run_name}.")
+        pxt_table_names = pxt.list_tables(pxt_run_name, recursive=False)
+        logger.info(f"Found {len(pxt_table_names)} tables in {pxt_run_name}.")
+        for pxt_table_name in pxt_table_names:
+            pxt_table = pxt.get_table(pxt_table_name)
+            size = pxt_table.count()
+            table_stats = {
+                "size": size,
+                "labels": get_ground_truth_labels_for_sam_single_click(pxt_table),
+            }
+            if size > 0:
+                row = pxt_table.sample(1).collect()[0]
+                table_stats["num_points"] = row["random_points"].shape[1]
+
+            logger.info(f"Stats for {pxt_table_name}: {table_stats}")
+
+
+if __name__ == "__main__":
+    show_pixeltable_status()

--- a/src/logging.py
+++ b/src/logging.py
@@ -110,7 +110,8 @@ def log_experiment_for_sam_single_click(
     mlflow.set_tracking_uri(cfg.logging.mlflow_tracking_uri)
 
     table_meta = pxt_table.get_metadata()
-    run_name = table_meta["name"]
+    table_name_splits = table_meta["path"].split(".")
+    run_name = ".".join(table_name_splits[1:])
     experiment_name = table_meta["path"].split(".")[0]
 
     experiment = mlflow.set_experiment(experiment_name)


### PR DESCRIPTION
This pull request introduces functionality to display the status of pixel tables and refines the logic for logging experiments related to single-click operations. The main additions include a new script for inspecting pixel tables and an update to the way experiment run names are derived.

### New functionality for pixel table status:

* [`pixeltable_status.py`](diffhunk://#diff-49b0cd8539bffb5ef09cf968571feca14b3babdd67256c1cede8dc9c72c6cff8R1-R42): Added a new script, `show_pixeltable_status`, which uses Hydra for configuration management to inspect pixel tables. It retrieves table statistics such as size, labels, and the number of random points, and logs this information using a structured approach.

### Refinement in experiment logging:

* [`src/logging.py`](diffhunk://#diff-3b360c3651fb5635c8746855dcf8498bc850981bb1f949c90a4c60eec218defbL113-R114): Updated the logic for deriving `run_name` in `log_experiment_for_sam_single_click` to use the path metadata of the pixel table, ensuring more precise naming conventions.