### PR TITLE
add all SAM 2.1 models to the experiment

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,11 +1,11 @@
 defaults:
   - _self_
   - dataset: plantseg
-  - sam@model.config: sam2.1_hiera_l
+  - sam@model.config: sam2.1_hiera_l # choose between: sam2.1_hiera_l sam2.1_hiera_t  sam2.1_hiera_s sam2.1_hiera_b+
 
 
 model:
-  hf_id: "facebook/sam2.1-hiera-large"
+  hf_id: facebook/sam2.1-hiera-large # choose between: facebook/sam2.1-hiera-large facebook/sam2.1-hiera-tiny facebook/sam2.1-hiera-small facebook/sam2.1-hiera-base-plus
   threshold: 0.0 # threshold to binarize the logits
 
 root: /storage/ml/

--- a/config/hydra/sweeper/params/deepglobe_roadextraction.yaml
+++ b/config/hydra/sweeper/params/deepglobe_roadextraction.yaml
@@ -1,2 +1,3 @@
 dataset: deepglobe_roadextraction
 dataset.args.split: train
+pipeline.use_bounding_box: False,True

--- a/config/hydra/sweeper/params/mvtec_ad.yaml
+++ b/config/hydra/sweeper/params/mvtec_ad.yaml
@@ -1,2 +1,3 @@
 dataset: mvtec_ad
 dataset.args.category: bottle,cable, capsule,carpet,grid,hazelnut,leather,metal_nut,pill,screw,tile,toothbrush,transistor,wood,zipper
+pipeline.use_bounding_box: False,True

--- a/config/hydra/sweeper/params/plantseg_and_kpi.yaml
+++ b/config/hydra/sweeper/params/plantseg_and_kpi.yaml
@@ -1,2 +1,3 @@
 dataset: plantseg,kpi_task1
 dataset.args.split: train,val,test
+pipeline.use_bounding_box: False,True

--- a/config/sam/sam2.1_hiera_b+.yaml
+++ b/config/sam/sam2.1_hiera_b+.yaml
@@ -1,0 +1,116 @@
+# @package _global_
+
+# Model
+model:
+  _target_: sam2.modeling.sam2_base.SAM2Base
+  image_encoder:
+    _target_: sam2.modeling.backbones.image_encoder.ImageEncoder
+    scalp: 1
+    trunk:
+      _target_: sam2.modeling.backbones.hieradet.Hiera
+      embed_dim: 112
+      num_heads: 2
+    neck:
+      _target_: sam2.modeling.backbones.image_encoder.FpnNeck
+      position_encoding:
+        _target_: sam2.modeling.position_encoding.PositionEmbeddingSine
+        num_pos_feats: 256
+        normalize: true
+        scale: null
+        temperature: 10000
+      d_model: 256
+      backbone_channel_list: [896, 448, 224, 112]
+      fpn_top_down_levels: [2, 3]  # output level 0 and 1 directly use the backbone features
+      fpn_interp_model: nearest
+
+  memory_attention:
+    _target_: sam2.modeling.memory_attention.MemoryAttention
+    d_model: 256
+    pos_enc_at_input: true
+    layer:
+      _target_: sam2.modeling.memory_attention.MemoryAttentionLayer
+      activation: relu
+      dim_feedforward: 2048
+      dropout: 0.1
+      pos_enc_at_attn: false
+      self_attention:
+        _target_: sam2.modeling.sam.transformer.RoPEAttention
+        rope_theta: 10000.0
+        feat_sizes: [64, 64]
+        embedding_dim: 256
+        num_heads: 1
+        downsample_rate: 1
+        dropout: 0.1
+      d_model: 256
+      pos_enc_at_cross_attn_keys: true
+      pos_enc_at_cross_attn_queries: false
+      cross_attention:
+        _target_: sam2.modeling.sam.transformer.RoPEAttention
+        rope_theta: 10000.0
+        feat_sizes: [64, 64]
+        rope_k_repeat: True
+        embedding_dim: 256
+        num_heads: 1
+        downsample_rate: 1
+        dropout: 0.1
+        kv_in_dim: 64
+    num_layers: 4
+
+  memory_encoder:
+      _target_: sam2.modeling.memory_encoder.MemoryEncoder
+      out_dim: 64
+      position_encoding:
+        _target_: sam2.modeling.position_encoding.PositionEmbeddingSine
+        num_pos_feats: 64
+        normalize: true
+        scale: null
+        temperature: 10000
+      mask_downsampler:
+        _target_: sam2.modeling.memory_encoder.MaskDownSampler
+        kernel_size: 3
+        stride: 2
+        padding: 1
+      fuser:
+        _target_: sam2.modeling.memory_encoder.Fuser
+        layer:
+          _target_: sam2.modeling.memory_encoder.CXBlock
+          dim: 256
+          kernel_size: 7
+          padding: 3
+          layer_scale_init_value: 1e-6
+          use_dwconv: True  # depth-wise convs
+        num_layers: 2
+
+  num_maskmem: 7
+  image_size: 1024
+  # apply scaled sigmoid on mask logits for memory encoder, and directly feed input mask as output mask
+  sigmoid_scale_for_mem_enc: 20.0
+  sigmoid_bias_for_mem_enc: -10.0
+  use_mask_input_as_output_without_sam: true
+  # Memory
+  directly_add_no_mem_embed: true
+  no_obj_embed_spatial: true
+  # use high-resolution feature map in the SAM mask decoder
+  use_high_res_features_in_sam: true
+  # output 3 masks on the first click on initial conditioning frames
+  multimask_output_in_sam: true
+  # SAM heads
+  iou_prediction_use_sigmoid: True
+  # cross-attend to object pointers from other frames (based on SAM output tokens) in the encoder
+  use_obj_ptrs_in_encoder: true
+  add_tpos_enc_to_obj_ptrs: true
+  proj_tpos_enc_in_obj_ptrs: true
+  use_signed_tpos_enc_to_obj_ptrs: true
+  only_obj_ptrs_in_the_past_for_eval: true
+  # object occlusion prediction
+  pred_obj_scores: true
+  pred_obj_scores_mlp: true
+  fixed_no_obj_ptr: true
+  # multimask tracking settings
+  multimask_output_for_tracking: true
+  use_multimask_token_for_obj_ptr: true
+  multimask_min_pt_num: 0
+  multimask_max_pt_num: 1
+  use_mlp_for_obj_ptr_proj: true
+  # Compilation flag
+  compile_image_encoder: False

--- a/config/sam/sam2.1_hiera_s.yaml
+++ b/config/sam/sam2.1_hiera_s.yaml
@@ -1,0 +1,119 @@
+# @package _global_
+
+# Model
+model:
+  _target_: sam2.modeling.sam2_base.SAM2Base
+  image_encoder:
+    _target_: sam2.modeling.backbones.image_encoder.ImageEncoder
+    scalp: 1
+    trunk:
+      _target_: sam2.modeling.backbones.hieradet.Hiera
+      embed_dim: 96
+      num_heads: 1
+      stages: [1, 2, 11, 2]
+      global_att_blocks: [7, 10, 13]
+      window_pos_embed_bkg_spatial_size: [7, 7]
+    neck:
+      _target_: sam2.modeling.backbones.image_encoder.FpnNeck
+      position_encoding:
+        _target_: sam2.modeling.position_encoding.PositionEmbeddingSine
+        num_pos_feats: 256
+        normalize: true
+        scale: null
+        temperature: 10000
+      d_model: 256
+      backbone_channel_list: [768, 384, 192, 96]
+      fpn_top_down_levels: [2, 3]  # output level 0 and 1 directly use the backbone features
+      fpn_interp_model: nearest
+
+  memory_attention:
+    _target_: sam2.modeling.memory_attention.MemoryAttention
+    d_model: 256
+    pos_enc_at_input: true
+    layer:
+      _target_: sam2.modeling.memory_attention.MemoryAttentionLayer
+      activation: relu
+      dim_feedforward: 2048
+      dropout: 0.1
+      pos_enc_at_attn: false
+      self_attention:
+        _target_: sam2.modeling.sam.transformer.RoPEAttention
+        rope_theta: 10000.0
+        feat_sizes: [64, 64]
+        embedding_dim: 256
+        num_heads: 1
+        downsample_rate: 1
+        dropout: 0.1
+      d_model: 256
+      pos_enc_at_cross_attn_keys: true
+      pos_enc_at_cross_attn_queries: false
+      cross_attention:
+        _target_: sam2.modeling.sam.transformer.RoPEAttention
+        rope_theta: 10000.0
+        feat_sizes: [64, 64]
+        rope_k_repeat: True
+        embedding_dim: 256
+        num_heads: 1
+        downsample_rate: 1
+        dropout: 0.1
+        kv_in_dim: 64
+    num_layers: 4
+
+  memory_encoder:
+      _target_: sam2.modeling.memory_encoder.MemoryEncoder
+      out_dim: 64
+      position_encoding:
+        _target_: sam2.modeling.position_encoding.PositionEmbeddingSine
+        num_pos_feats: 64
+        normalize: true
+        scale: null
+        temperature: 10000
+      mask_downsampler:
+        _target_: sam2.modeling.memory_encoder.MaskDownSampler
+        kernel_size: 3
+        stride: 2
+        padding: 1
+      fuser:
+        _target_: sam2.modeling.memory_encoder.Fuser
+        layer:
+          _target_: sam2.modeling.memory_encoder.CXBlock
+          dim: 256
+          kernel_size: 7
+          padding: 3
+          layer_scale_init_value: 1e-6
+          use_dwconv: True  # depth-wise convs
+        num_layers: 2
+
+  num_maskmem: 7
+  image_size: 1024
+  # apply scaled sigmoid on mask logits for memory encoder, and directly feed input mask as output mask
+  sigmoid_scale_for_mem_enc: 20.0
+  sigmoid_bias_for_mem_enc: -10.0
+  use_mask_input_as_output_without_sam: true
+  # Memory
+  directly_add_no_mem_embed: true
+  no_obj_embed_spatial: true
+  # use high-resolution feature map in the SAM mask decoder
+  use_high_res_features_in_sam: true
+  # output 3 masks on the first click on initial conditioning frames
+  multimask_output_in_sam: true
+  # SAM heads
+  iou_prediction_use_sigmoid: True
+  # cross-attend to object pointers from other frames (based on SAM output tokens) in the encoder
+  use_obj_ptrs_in_encoder: true
+  add_tpos_enc_to_obj_ptrs: true
+  proj_tpos_enc_in_obj_ptrs: true
+  use_signed_tpos_enc_to_obj_ptrs: true
+  only_obj_ptrs_in_the_past_for_eval: true
+  # object occlusion prediction
+  pred_obj_scores: true
+  pred_obj_scores_mlp: true
+  fixed_no_obj_ptr: true
+  # multimask tracking settings
+  multimask_output_for_tracking: true
+  use_multimask_token_for_obj_ptr: true
+  multimask_min_pt_num: 0
+  multimask_max_pt_num: 1
+  use_mlp_for_obj_ptr_proj: true
+  # Compilation flag
+  compile_image_encoder: False

--- a/config/sam/sam2.1_hiera_t.yaml
+++ b/config/sam/sam2.1_hiera_t.yaml
@@ -1,0 +1,121 @@
+# @package _global_
+
+# Model
+model:
+  _target_: sam2.modeling.sam2_base.SAM2Base
+  image_encoder:
+    _target_: sam2.modeling.backbones.image_encoder.ImageEncoder
+    scalp: 1
+    trunk:
+      _target_: sam2.modeling.backbones.hieradet.Hiera
+      embed_dim: 96
+      num_heads: 1
+      stages: [1, 2, 7, 2]
+      global_att_blocks: [5, 7, 9]
+      window_pos_embed_bkg_spatial_size: [7, 7]
+    neck:
+      _target_: sam2.modeling.backbones.image_encoder.FpnNeck
+      position_encoding:
+        _target_: sam2.modeling.position_encoding.PositionEmbeddingSine
+        num_pos_feats: 256
+        normalize: true
+        scale: null
+        temperature: 10000
+      d_model: 256
+      backbone_channel_list: [768, 384, 192, 96]
+      fpn_top_down_levels: [2, 3]  # output level 0 and 1 directly use the backbone features
+      fpn_interp_model: nearest
+
+  memory_attention:
+    _target_: sam2.modeling.memory_attention.MemoryAttention
+    d_model: 256
+    pos_enc_at_input: true
+    layer:
+      _target_: sam2.modeling.memory_attention.MemoryAttentionLayer
+      activation: relu
+      dim_feedforward: 2048
+      dropout: 0.1
+      pos_enc_at_attn: false
+      self_attention:
+        _target_: sam2.modeling.sam.transformer.RoPEAttention
+        rope_theta: 10000.0
+        feat_sizes: [64, 64]
+        embedding_dim: 256
+        num_heads: 1
+        downsample_rate: 1
+        dropout: 0.1
+      d_model: 256
+      pos_enc_at_cross_attn_keys: true
+      pos_enc_at_cross_attn_queries: false
+      cross_attention:
+        _target_: sam2.modeling.sam.transformer.RoPEAttention
+        rope_theta: 10000.0
+        feat_sizes: [64, 64]
+        rope_k_repeat: True
+        embedding_dim: 256
+        num_heads: 1
+        downsample_rate: 1
+        dropout: 0.1
+        kv_in_dim: 64
+    num_layers: 4
+
+  memory_encoder:
+      _target_: sam2.modeling.memory_encoder.MemoryEncoder
+      out_dim: 64
+      position_encoding:
+        _target_: sam2.modeling.position_encoding.PositionEmbeddingSine
+        num_pos_feats: 64
+        normalize: true
+        scale: null
+        temperature: 10000
+      mask_downsampler:
+        _target_: sam2.modeling.memory_encoder.MaskDownSampler
+        kernel_size: 3
+        stride: 2
+        padding: 1
+      fuser:
+        _target_: sam2.modeling.memory_encoder.Fuser
+        layer:
+          _target_: sam2.modeling.memory_encoder.CXBlock
+          dim: 256
+          kernel_size: 7
+          padding: 3
+          layer_scale_init_value: 1e-6
+          use_dwconv: True  # depth-wise convs
+        num_layers: 2
+
+  num_maskmem: 7
+  image_size: 1024
+  # apply scaled sigmoid on mask logits for memory encoder, and directly feed input mask as output mask
+  # SAM decoder
+  sigmoid_scale_for_mem_enc: 20.0
+  sigmoid_bias_for_mem_enc: -10.0
+  use_mask_input_as_output_without_sam: true
+  # Memory
+  directly_add_no_mem_embed: true
+  no_obj_embed_spatial: true
+  # use high-resolution feature map in the SAM mask decoder
+  use_high_res_features_in_sam: true
+  # output 3 masks on the first click on initial conditioning frames
+  multimask_output_in_sam: true
+  # SAM heads
+  iou_prediction_use_sigmoid: True
+  # cross-attend to object pointers from other frames (based on SAM output tokens) in the encoder
+  use_obj_ptrs_in_encoder: true
+  add_tpos_enc_to_obj_ptrs: true
+  proj_tpos_enc_in_obj_ptrs: true
+  use_signed_tpos_enc_to_obj_ptrs: true
+  only_obj_ptrs_in_the_past_for_eval: true
+  # object occlusion prediction
+  pred_obj_scores: true
+  pred_obj_scores_mlp: true
+  fixed_no_obj_ptr: true
+  # multimask tracking settings
+  multimask_output_for_tracking: true
+  use_multimask_token_for_obj_ptr: true
+  multimask_min_pt_num: 0
+  multimask_max_pt_num: 1
+  use_mlp_for_obj_ptr_proj: true
+  # Compilation flag
+  # HieraT does not currently support compilation, should always be set to False
+  compile_image_encoder: False

--- a/run/deepglobe_roadextraction.sh
+++ b/run/deepglobe_roadextraction.sh
@@ -1,1 +1,4 @@
-python -m single_click_with_sam --multirun  '+hydra/sweeper/params=deepglobe_roadextraction'
+python -m single_click_with_sam --multirun  '+hydra/sweeper/params=deepglobe_roadextraction' model.hf_id=facebook/sam2.1-hiera-large sam@model.config=sam2.1_hiera_l
+python -m single_click_with_sam --multirun  '+hydra/sweeper/params=deepglobe_roadextraction' model.hf_id=facebook/sam2.1-hiera-tiny sam@model.config=sam2.1_hiera_t
+python -m single_click_with_sam --multirun  '+hydra/sweeper/params=deepglobe_roadextraction' model.hf_id=facebook/sam2.1-hiera-small sam@model.config=sam2.1_hiera_s
+python -m single_click_with_sam --multirun  '+hydra/sweeper/params=deepglobe_roadextraction' model.hf_id=facebook/sam2.1-hiera-base-plus sam@model.config=sam2.1_hiera_b+

--- a/run/mvtec_ad.sh
+++ b/run/mvtec_ad.sh
@@ -1,1 +1,4 @@
-python -m single_click_with_sam --multirun  '+hydra/sweeper/params=mvtec_ad'
+python -m single_click_with_sam --multirun  '+hydra/sweeper/params=mvtec_ad' model.hf_id=facebook/sam2.1-hiera-large sam@model.config=sam2.1_hiera_l
+python -m single_click_with_sam --multirun  '+hydra/sweeper/params=mvtec_ad' model.hf_id=facebook/sam2.1-hiera-tiny sam@model.config=sam2.1_hiera_t
+python -m single_click_with_sam --multirun  '+hydra/sweeper/params=mvtec_ad' model.hf_id=facebook/sam2.1-hiera-small sam@model.config=sam2.1_hiera_s
+python -m single_click_with_sam --multirun  '+hydra/sweeper/params=mvtec_ad' model.hf_id=facebook/sam2.1-hiera-base-plus sam@model.config=sam2.1_hiera_b+

--- a/run/plantseg_and_kpi.sh
+++ b/run/plantseg_and_kpi.sh
@@ -1,1 +1,4 @@
-python -m single_click_with_sam --multirun  '+hydra/sweeper/params=plantseg_and_kpi'
+python -m single_click_with_sam --multirun  '+hydra/sweeper/params=plantseg_and_kpi' model.hf_id=facebook/sam2.1-hiera-large sam@model.config=sam2.1_hiera_l
+python -m single_click_with_sam --multirun  '+hydra/sweeper/params=plantseg_and_kpi' model.hf_id=facebook/sam2.1-hiera-tiny sam@model.config=sam2.1_hiera_t
+python -m single_click_with_sam --multirun  '+hydra/sweeper/params=plantseg_and_kpi' model.hf_id=facebook/sam2.1-hiera-small sam@model.config=sam2.1_hiera_s
+python -m single_click_with_sam --multirun  '+hydra/sweeper/params=plantseg_and_kpi' model.hf_id=facebook/sam2.1-hiera-base-plus sam@model.config=sam2.1_hiera_b+


### PR DESCRIPTION
This pull request introduces significant updates to model configurations, dataset sweeper parameters, and script execution commands to support multiple model variants (`sam2.1_hiera_*`) and enhance flexibility in bounding box usage. Additionally, it adds detailed definitions for new model configurations (`sam2.1_hiera_t`, `sam2.1_hiera_s`, and `sam2.1_hiera_b+`). Below are the most important changes grouped by theme:

### Model Configuration Updates:
* [`config/config.yaml`](diffhunk://#diff-38df760413887d0cc4ee5707919e6390456a863d326f6080644cc3d9c72e4bbaL4-R8): Updated `sam@model.config` and `model.hf_id` to support multiple model variants (`sam2.1_hiera_l`, `sam2.1_hiera_t`, `sam2.1_hiera_s`, `sam2.1_hiera_b+`) with corresponding descriptions.

### Dataset Sweeper Parameter Enhancements:
* Added `pipeline.use_bounding_box` parameter (values: `False,True`) to dataset sweeper configurations for `deepglobe_roadextraction`, `mvtec_ad`, and `plantseg_and_kpi` datasets. [[1]](diffhunk://#diff-41cd68582df2c8b669ca5ea99b29fe19f12bc45d93774d1c9edefb6fac593869R3) [[2]](diffhunk://#diff-9574326c6796bc18deea0ca1f82eb6354aea40f14668a2ec008e3b1c9eb54fc1R3) [[3]](diffhunk://#diff-4e3b24670389687ab194e712c16e9de9451e8e4f7abb64f9b82d156ca415cfd5R3)

### New Model Definitions:
* [`config/sam/sam2.1_hiera_b+.yaml`](diffhunk://#diff-4f391ee5d0ec22947638a66a1382fede6f757884b8dbdbef48ff82a24875ad6dR1-R116): Added configuration for the `sam2.1_hiera_b+` model, including detailed specifications for the image encoder, memory attention, memory encoder, and multimask tracking settings.
* [`config/sam/sam2.1_hiera_s.yaml`](diffhunk://#diff-f387ef2efc580e4effa53139f85f6703d537c43223121a1b9e4ac2f60295c168R1-R119): Added configuration for the `sam2.1_hiera_s` model with tailored encoder and decoder settings.
* [`config/sam/sam2.1_hiera_t.yaml`](diffhunk://#diff-254c6fb1ffdea5e8e40a43d8109b69628768f8507d65a534b882b627df5767d3R1-R121): Added configuration for the `sam2.1_hiera_t` model with specific attention and positional encoding settings.

### Script Updates for Model Variants:
* Updated execution scripts (`run/deepglobe_roadextraction.sh`, `run/mvtec_ad.sh`, `run/plantseg_and_kpi.sh`) to include commands for running all supported model variants (`sam2.1_hiera_l`, `sam2.1_hiera_t`, `sam2.1_hiera_s`, `sam2.1_hiera_b+`). [[1]](diffhunk://#diff-62f9b53c7cd0afe80c6c914674a13b294522be7ebb42d38391478ce2062c9432L1-R4) [[2]](diffhunk://#diff-bd85b20acde7865f118efc87b9fdac20f3a3de2e7eac2cbbf63a8871ddc21ae1L1-R4) [[3]](diffhunk://#diff-38f6b31079636af5328aa5628170e825373ce013255d14d11feb2241b35b3495L1-R4)